### PR TITLE
Add PlainSocketFactory and make it a default fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ Any authorization on the server must be configured using the `jmx.remote.accessc
 - Applications can also implement the `nl.futureedge.simple.jmx.access.JMXAccessController` interface instead of using the supplied implementations to fully customize their access control.
 
 ### Connections (client-side and server-side)
-Connections are made via standaard Java sockets. Simple JMX provides two connection provider out of the box:
-- Anonymous SSL (allows operation without certificates) ****default***\*
+Connections are made via standaard Java sockets. Simple JMX provides three connection provider out of the box:
+- Plain sockets (provides no security) ****default***\*
+- Anonymous SSL (allows operation without certificates, but note that these cipher suites are often not enabled)
 - System SSL (uses the default Java SSL provider)
 
 Any connection configuration (on the client or the server) must be configured using the `jmx.remote.socketfactory` key in the environment; the value should be an object instance that implements the `nl.futureedge.jmx.socket.JMXSocketFactory` interface:
 
+- Plain socket implementation (`nl.futureedge.simple.jmx.socket.PlainSocketFactory`) does not have any configuration.
 - The anonymous SSL implementation (`nl.futureedge.simple.jmx.socket.AnonymousSslSocketFactory`) does not have any specific configuration.
 - The system SSL implementation (`nl.futureedge.simple.jmx.socket.SystemSslSocketFactory`) uses the system default SSLContext and should be configured using the [system configuration](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html).
 - Applications can also implement the `nl.futureedge.simple.jmx.socket.JMXSocketFactory` interface to fully customize their connections.

--- a/src/main/java/nl/futureedge/simple/jmx/environment/Environment.java
+++ b/src/main/java/nl/futureedge/simple/jmx/environment/Environment.java
@@ -10,6 +10,7 @@ import nl.futureedge.simple.jmx.access.JMXAccessController;
 import nl.futureedge.simple.jmx.authenticator.StaticAuthenticator;
 import nl.futureedge.simple.jmx.socket.AnonymousSslSocketFactory;
 import nl.futureedge.simple.jmx.socket.JMXSocketFactory;
+import nl.futureedge.simple.jmx.socket.PlainSocketFactory;
 import nl.futureedge.simple.jmx.socket.SslConfigurationException;
 
 /**
@@ -33,6 +34,8 @@ public final class Environment {
 
     public static final String KEY_THREADPRIORITY = "jmx.remote.threadpriority";
 
+    public static final String KEY_ANONYMOUS_CIPHERS = "jmx.remote.anonymousciphers";
+
     public static JMXSocketFactory determineSocketFactory(final Map<String, ?> environment) throws IOException {
         // Custom socket factory via the environment
         final JMXSocketFactory custom = (JMXSocketFactory) environment.get(KEY_SOCKETFACTORY);
@@ -41,10 +44,14 @@ public final class Environment {
         }
 
         // Default: no authentication
-        try {
-            return new AnonymousSslSocketFactory();
-        } catch (final SslConfigurationException e) {
-            throw new IOException("Could not create default socket factory", e);
+        if (environment.containsKey(KEY_ANONYMOUS_CIPHERS)) {
+            try {
+                return new AnonymousSslSocketFactory();
+            } catch (final SslConfigurationException e) {
+                throw new IOException("Could not create default socket factory", e);
+            }
+        } else {
+            return new PlainSocketFactory();
         }
     }
 

--- a/src/main/java/nl/futureedge/simple/jmx/socket/PlainSocketFactory.java
+++ b/src/main/java/nl/futureedge/simple/jmx/socket/PlainSocketFactory.java
@@ -1,0 +1,48 @@
+package nl.futureedge.simple.jmx.socket;
+
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Socket factory without any security at all.
+ */
+public class PlainSocketFactory implements JMXSocketFactory {
+
+	private static final int BACKLOG = 50;
+	private static final Logger LOGGER = Logger.getLogger(PlainSocketFactory.class.getName());
+
+	/**
+	 * Create a client socket.
+	 * @param serviceUrl jmx service url
+	 * @return client socket
+	 * @throws IOException if an I/O error occurs when creating the socket
+	 */
+	@Override
+	public Socket createSocket(final JMXServiceURL serviceUrl) throws IOException {
+		final Socket socket = new Socket(serviceUrl.getHost(), serviceUrl.getPort());
+		socket.setKeepAlive(true);
+
+		LOGGER.log(Level.FINE, "Created client socket");
+		return socket;
+	}
+
+	/**
+	 * Create a server socket.
+	 * @param serviceUrl jmx service url
+	 * @return server socket
+	 * @throws IOException if an I/O error occurs when creating the socket
+	 */
+	@Override
+	public ServerSocket createServerSocket(final JMXServiceURL serviceUrl) throws IOException {
+		final InetAddress host = InetAddress.getByName(serviceUrl.getHost());
+		final ServerSocket serverSocket = new ServerSocket(serviceUrl.getPort(), BACKLOG, host);
+
+		LOGGER.log(Level.FINE, "Created server socket");
+		return serverSocket;
+	}
+}


### PR DESCRIPTION
Result of #1. Adds `PlainSocketFactory`, which is a simplified version of `AnonymousSslSocketFactory` without any SSL - just through plain sockets. This new socket factory is then made default fallback, instead of the anonymous one, which is still available through environment key. All tests are passing.


*After a few hours of messing with proxies and RMI, I am so happy I found this project. Thank you for creating and publishing it!*